### PR TITLE
Fix failing webserver config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   output: { path: path.join(__dirname, "build"), filename: "index.bundle.js" },
   mode: process.env.NODE_ENV || "development",
   resolve: { modules: [path.resolve(__dirname, "src"), "node_modules"] },
-  devServer: { contentBase: path.join(__dirname, "src") },
+  devServer: { static: { directory: path.join(__dirname, "src") } },
   module: {
     rules: [
       {


### PR DESCRIPTION
`contentBase` was deprecated and replaced with `static`